### PR TITLE
fix boot3 autoconfig, add more app.props files

### DIFF
--- a/examples/demoapp/BUILD
+++ b/examples/demoapp/BUILD
@@ -108,7 +108,17 @@ springboot(
     deps_banned = ["junit", "mockito", "lombok"],
 
     # Specify optional JVM args to use when the application is launched with 'bazel run'
-    bazelrun_jvm_flags = "-Dcustomprop=gold -DcustomProp2=silver",
+    bazelrun_jvm_flags = "-Dcustomprop=gold -DcustomProp2=silver", # old way
+    bazelrun_jvm_flag_list = ["-Dcustomprop3=bronze", "-DcustomProp4=copper"], # new way
+    bazelrun_addexports = [
+        "java.base/java.base=ALL-UNNAMED",
+        "java.base/java.io=ALL-UNNAMED",
+        "java.base/java.nio=ALL-UNNAMED",
+    ],
+    bazelrun_addopens = [
+        "java.base/java.util.concurrent=ALL-UNNAMED",
+        "java.base/java.util.logging=ALL-UNNAMED",
+    ],
 
     # data files can be made available in the working directory for when the app is launched with bazel run
     bazelrun_data = ["example_data.txt"],

--- a/examples/demoapp/application.properties
+++ b/examples/demoapp/application.properties
@@ -1,0 +1,1 @@
+demoapp.config.rootdirectory=loaded

--- a/examples/demoapp/config/application.properties
+++ b/examples/demoapp/config/application.properties
@@ -1,0 +1,1 @@
+demoapp.config.configsubdirectory=loaded

--- a/examples/demoapp/src/main/java/com/sample/SampleAutoConfiguration.java
+++ b/examples/demoapp/src/main/java/com/sample/SampleAutoConfiguration.java
@@ -1,10 +1,29 @@
 package com.sample;
 
 import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
 
 import org.springframework.boot.loader.tools.SignalUtils;
 
+
 public class SampleAutoConfiguration {
+
+    @Value("${demoapp.config.internal:not found}")
+    String config_internal;
+
+    @Value("${demoapp.config.rootdirectory:not found}")
+    String config_external_root;
+
+    @Value("${demoapp.config.configsubdirectory:not found}")
+    String config_external_configsub;
+
+    @PostConstruct
+    public void logLoadedProperties() {
+        System.out.println("SampleAutoConfiguration loading of application.properties files:");
+        System.out.println("  internal application.properties: "+config_internal);
+        System.out.println("  external application.properties: "+config_external_root);
+        System.out.println("  external config/application.properties: "+config_external_configsub);
+    }
 
     @PostConstruct
     public void setupSignalHandler() {

--- a/examples/demoapp/src/main/resources/META-INF/spring.factories
+++ b/examples/demoapp/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.sample.SampleAutoConfiguration

--- a/examples/demoapp/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/examples/demoapp/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.sample.SampleAutoConfiguration

--- a/examples/demoapp/src/main/resources/application.properties
+++ b/examples/demoapp/src/main/resources/application.properties
@@ -9,3 +9,5 @@
 #  http://localhost:8080/actuator/beans
 #  http://localhost:8080/actuator/info
 management.endpoints.web.exposure.include=*
+
+demoapp.config.internal=loaded


### PR DESCRIPTION
Two enhancements:
- fixed auto config loading, something missed during previous Boot3 upgrade
- added demo case for multiple application.properties file locations, to be tested for work on [this Bazel Run config feature](https://github.com/salesforce/rules_spring/issues/135)